### PR TITLE
Storeman 0.2.12: Do not assign repo in global section

### DIFF
--- a/rpm/harbour-storeman.changes
+++ b/rpm/harbour-storeman.changes
@@ -1,3 +1,6 @@
+* Tue Jan 27 2022 olf <https://github.com/Olf0> 0.2.12
+- Omit ssu/features.d/mentaljam-obs.ini
+
 * Sat Sep 18 2021 Petr Tsymbarovich <petr@tsymbarovich.ru> 0.2.11
 - Use the new share API on SFOS 4.2
 

--- a/rpm/harbour-storeman.spec
+++ b/rpm/harbour-storeman.spec
@@ -1,6 +1,6 @@
 Name:           harbour-storeman
 Summary:        OpenRepos Client for Sailfish OS
-Version:        0.2.11
+Version:        0.2.12
 Release:        1
 Group:          Qt/Qt
 License:        MIT
@@ -49,12 +49,15 @@ desktop-file-install --delete-original       \
   --dir %{buildroot}%{_datadir}/applications \
    %{buildroot}%{_datadir}/applications/*.desktop
 
-%post
-ssu ur || true
+%posttrans
+rm -f /var/cache/ssu/features.ini
+ssu ar mentaljam-obs 'https://repo.sailfishos.org/obs/home:/mentaljam/%%(release)_%%(arch)/'
+ssu ur
 
 %postun
-rm -f /var/cache/ssu/features.ini || true
-ssu ur || true
+ssu rr mentaljam-obs
+rm -f /var/cache/ssu/features.ini
+ssu ur
 
 %files
 %defattr(-,root,root,-)
@@ -64,4 +67,3 @@ ssu ur || true
 %{_datadir}/icons/hicolor/*/apps/%{name}.png
 %{_datadir}/mapplauncherd/privileges.d/%{name}
 %{_datadir}/dbus-1/services/harbour.storeman.service
-%{_datadir}/ssu/features.d/mentaljam-obs.ini


### PR DESCRIPTION
- [storeman.spec: Do not assign repo in global section](https://github.com/Olf0/harbour-storeman/commit/e6badb7a38e60f700bf86ead83234ef842f1dcf9)
   - Fix issue https://github.com/storeman-developers/harbour-storeman/issues/157
   - ssu & rm -f always return 0
   - Switch http://repo.merproject.org/ -> https://repo.sailfishos.org/
   - Increase version number
- [storeman.changes: Add 0.2.12](https://github.com/Olf0/harbour-storeman/commit/f7896c74caeedb32d6a9e5061e722138f3d47815)